### PR TITLE
Update version links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@
 - Contributeur du projet:
   - Pour la base de données: [josoavj](https://github.com/josoavj)
   - Pour l'interface: [Aina Maminirina](https://github.com/AinaMaminirina18)
-- Final Version: [Planificator 1.0]()
-
+- 1.0: [Planificator 1.0](https://github.com/APEXNovaLabs/Planificator.1.0)
+- 1.1: [Planificator 1.1](https://github.com/APEXNovaLabs/Planificator-1.1.1)
+  
 ### 📂 Structuration des dossiers
 
 ```


### PR DESCRIPTION
This pull request updates the project version references in the `README.md` to include direct links to both version 1.0 and the newly added version 1.1 of Planificator. This makes it easier for users to access each release.

Documentation updates:

* Added a link for version 1.0 (`Planificator 1.0`) and introduced a new link for version 1.1 (`Planificator 1.1`) in the version history section of the `README.md`.